### PR TITLE
Add basic git hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ endif
 	check-downstream check-reverse-dependencies clean clean-all clean-tar \
 	compile-attributes force help install install-only install-dependencies install-upstream \
 	maker .maker maker-README.md remove release roxygen rd run-demos \
-	targets usage win-builder version \
+	setup-git-hooks targets usage win-builder version \
 	pkg-home pkg-news pkg-refs pkg-vigs pkg-all pkgdown README.md NEWS
 
 #'@section Usage
@@ -258,6 +258,9 @@ set-default-pkg: #' set new default PKG
 remove-default-pkg: #' remove current default PKG
 	(test -f ${MAKERRC} && \
 	sed -i --follow-symlinks '/^[[:space:]]*PKG[[:space:]]*=.*/d' ${MAKERRC})
+
+setup-git-hooks: #' setup git hooks
+	${MAKERDIR}/hooks/setup-hooks.sh ${PKGDIR}
 
 #'@section Getting help
 help target usage: #' print this help text

--- a/hooks/pre-commit-READMERmd.sh
+++ b/hooks/pre-commit-READMERmd.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [[ README.Rmd -nt README.md ]]; then
+  echo "README.md is out of date; please re-knit README.Rmd"
+  exit 1
+fi

--- a/hooks/pre-commit-news.sh
+++ b/hooks/pre-commit-news.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [[ -f NEWS.md ]] ; then
+    sed '/^# .*$$/d; /^## .*$$/{s/^## //g; p; s/./-/g}; /^###\+/{s/./\u&/g}; s/^##\+ //g; 1,2{/^[[:space:]]*$$/d}; s/\[\(#[0-9]\+\)\]([^)]\+)/\1/g' NEWS.md > NEWS
+    git add NEWS
+fi

--- a/hooks/pre-commit-newsmd.sh
+++ b/hooks/pre-commit-newsmd.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+REPOURL=$(git config --get remote.origin.url | sed 's/^.*git@github.com:/https:\/\/github.com\//; s/.git$/\/issues\//g; s/\//\\\//g')
+
+# Replace #XXX issue numbers by [#XXX](https://github.com/lgatto/MSnbase/issues/XXX
+sed -i '/\(^\|[^[]\)#[0-9]\+[^]]\?/{s/#\([0-9]\+\)/[#\1]('${REPOURL}'\1)/g;h};${x;/./{x;q1};x;q0}' NEWS.md
+## explanation:
+## sed -i (in place replacement)
+## /[^[]#[0-9]\+[^]]/ search for issues #XXX not already surounded by "["/"]"
+## and apply the substition command just to this numbers
+## {s/#\([0-9]\+\)/[#\1](https:\/\/github.com\/lgatto\/MSnbase\/issues\/\1)/g;}
+## build the link
+## "h" copy the result into the "hold space" (initial empty)
+## ${x;/./{x;q1};x;q0} when add the end of file "$", swap "hold" and "pattern"
+## space via "x", if now anything was found in the "pattern" space "/./" swap
+## again and return 1 (q1); if nothing was found also swap and return 0 (q0)
+
+if [[ $? -ne 0 ]]; then
+    echo "Issue link in NEWS.md was modified by '$(basename ${0})' hook; please review and recommit"
+    exit 1
+fi

--- a/hooks/setup-hooks.sh
+++ b/hooks/setup-hooks.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+if [[ ! -d "${1}" ]] ; then
+    echo "Directory ${1} doesn't exist!"
+    exit 1
+fi
+
+GITHOOKDIR="${1}/.git/hooks"
+PRECOMMIT="${GITHOOKDIR}/pre-commit"
+MAKERHOOKDIR="$(dirname $(readlink -f ${0}))"
+
+if [[ ! -f "${PRECOMMIT}" ]] ; then
+    touch ${PRECOMMIT}
+    chmod +x ${PRECOMMIT}
+fi
+
+for h in ${MAKERHOOKDIR}/pre-commit*; do
+    grep "${h}" "${PRECOMMIT}" || echo "${h} || exit 1" >> "${PRECOMMIT}"
+done


### PR DESCRIPTION
This PR allows you to call `make PKG=MSnbase setup-git-hooks` (see #30). It will create a `.git/hooks/pre-commit` file if it doesn't exist. Then it calls the hooks from `${MAKERDIR}/hooks`. The advantage is that we just have one place to maintain all hooks for all R based git projects. The disadvantage of the current solution is that you don't have the choice to use just a specific hook (ok, you could add/remove the specific line in your `.git/hooks/pre-commit` manually).

The first hooks:
1. Convert issue numbers in `NEWS.md` to github links.
2. Create `NEWS` from `NEWS.md`.
3. Abort `git commit` if the `README.Rmd` was updated but the `README.md` is still the old one.

What do you think?